### PR TITLE
New code of conduct, updated security email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,44 +1,134 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior. We invite all those who participate in the hapi project to help us create a safe and productive experiences for everyone, regardless of gender, gender identity, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+## Our Pledge
 
-Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer, but nevertheless, the project maintainers have the final say even when you disagree.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
-## Disclaimer
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-The hapi organization's repositories, websites, Slack channels, and other venues of interaction are not public places, even when they are hosted by public services. You are a guest and expected to behave as if you are visiting someone else's home. In this case, the project maintainers' home.
+## Our Standards
 
-The hapi project is managed under the [BDFL model](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life). If you are unwilling to accept the final decision of the maintainers, your only acceptable recourse is to leave. The code is licensed under a liberal open source license allowing you to fork and make the changes you wish elsewhere.
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This policy applies to any interaction with other hapi community members. Whether on GitHub, Twitter, IRC, Slack, or any other venue, your actions matter. We expect all members of the hapi community, to behave respectfully to others regardless of venue and regardless whether the communication is about the hapi project or not.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
-Expressing opinions which may offend others in public or in private may trigger a policy violation review. Our goal is to provide a safe environment and when a conflict arises between one person's freedom of expression and another's sense of safety, we will take the necessary actions to ensure the project remains a safe environment for all.
+## Enforcement
 
-## Unacceptable Behavior
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+tsc@hapi.dev.
+All complaints will be reviewed and investigated promptly and fairly.
 
-The following behaviors are considered harassment and are unacceptable within our community:
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
-- Violence, threats of violence or violent language directed against another person.
-- Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
-- Posting or displaying sexually explicit or violent material.
-- Posting or threatening to post other people's personally identifying information ("doxing").
-- Personal insults, particularly those related to gender, gender identity, sexual orientation, race, religion, or disability.
-- Inappropriate photography or recording.
-- Inappropriate physical contact. You should have someone's consent before touching them.
-- Unwelcome sexual attention. This includes, sexualized comments or jokes, inappropriate touching, groping, and unwelcomed sexual advances.
-- Deliberate intimidation, stalking or following (online or in person).
-- Advocating for, or encouraging, any of the above behavior.
+## Enforcement Guidelines
 
-## Consequences of Unacceptable Behavior
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
-Unacceptable behavior will not be tolerated.
+### 1. Correction
 
-When possible, a warning will be given before taking other actions. Anyone asked to stop unacceptable behavior is expected to comply immediately. If you disagree, first take steps to suspend and remove the offending materials or actions, then raise your objections in a polite and appropriate manner. If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should reach out via the contacts below with a description of your grievance.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-If a community member engages in unacceptable behavior, the maintainers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning. A person's past contribution to the hapi project will not be considered when evaluating their behavior.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
-## Contact Information
+### 2. Warning
 
-You may contact one or more of the listed [team members](https://github.com/orgs/hapijs/people) or support@sideway.com.
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+## Appendix A: The tsc@hapi.dev Alias
+
+*Note*: At the current time, all email sent to the `tsc@hapi.dev` email
+alias is copied to all members of the [hapi Technical Steering Committee](README.md#tsc-members).
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # .github
-Default organization policies
+Organization policies
+
+## Community Membership
+The hapi community consists (non-exclusively) of participants in GitHub issues and PRs throughout the organization, users of the the hapi [Slack](https://join.slack.com/t/hapihour/shared_invite/zt-g5ortpsk-ErlnRA2rUcPIWES21oXBOg), project contributors, and the Technical Steering Committee (TSC).
+
+### TSC Members
+ - Devin Ivy ([@devinivy](https://github.com/devinivy))
+ - Jonas Pauthier ([@nargonath](https://github.com/nargonath))
+ - Lloyd Benson ([@lloydbenson](https://github.com/lloydbenson))
+ - Nathan LaFreniere ([@nlf](https://github.com/nlf))
+ - Peter Henning ([@petreboy14](https://github.com/petreboy14))
+ - Wyatt Lyon Preul ([@geek](https://github.com/geek))
+ - Colin Ihrig ([@cjihrig](https://github.com/cjihrig))
+
+## Code of Conduct
+> See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## Security and Disclosure
+> See [SECURITY.md](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 Let’s keep things simple –
 
-If you think you have identified a security related issue with any hapi module or repository, please report it immediately to **security@sideway.com**. If you are not sure, don’t worry. Better safe than sorry – just send an email. Do not open issues related to any security concerns publicly. Please do not include anyone else on the disclosure email.
+If you think you have identified a security related issue with any hapi module or repository, please report it immediately to **security@hapi.dev**. If you are not sure, don’t worry. Better safe than sorry – just send an email. Do not open issues related to any security concerns publicly. Please do not include anyone else on the disclosure email.
 
 When reporting an issue, include as much information as possible, but no need to fill fancy forms or answer tedious questions. Just tell us what you found, how to reproduce it, and any concerns you have about it. We will respond as soon as possible and follow up with any missing information.
 
@@ -10,4 +10,4 @@ When reporting an issue, include as much information as possible, but no need to
 
 The hapi organization reports all identified security issues to the [npm Security Team](https://www.npmjs.com/advisories) as soon as an issue has been confirmed and works closely to issue responsible disclosures. When issues are disclosed, the person or team responsible for the discovery receives full credit.
 
-In general, public disclosure are made after the issue has been fully identified and a patch is ready to be released. Companies with an active [commercial support plan]( https://hapi.dev/support/) receive advance notice of upcoming security disclosures and patches up to 72 hours prior to public disclosure.
+In general, public disclosure are made after the issue has been fully identified and a patch is ready to be released.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,9 +6,5 @@ The portal contains all the resources needed to successfully build hapi-based ap
 
 ## Community Support
 
-Free support is always available on GitHub. Just open an issue with your question and a community member will try to help. For faster response, join the hapi [Slack channel]( https://join.slack.com/t/hapihour/shared_invite/enQtNTA5MDUzOTAzOTU4LTUyZmFiYjkyMTBmNDcyMmI2MmRjMzg4Y2YzNTlmNzUzNjViN2U1NmYyY2NjYjhiYWU4MGE2OTFhZDRlYWMyZDY) – it’s where many community members hang out and help each other.
+Free support is always available on GitHub. Just open an issue with your question and a community member will try to help. For faster response, join the hapi [Slack](https://join.slack.com/t/hapihour/shared_invite/zt-g5ortpsk-ErlnRA2rUcPIWES21oXBOg) – it’s where many community members hang out and help each other.
 Like all open source projects, free support is constrained by the availability of volunteer resources.
-
-## Commercial Support
-
-Commercial licensing and support is available for legacy versions (v16, v17, v18, and v19). Please visit the [hapi support page](https://hapi.dev/support/) for more information.


### PR DESCRIPTION
Under the new hapi leadership (see https://github.com/hapijs/hapi/issues/4113), our intention is to adopt the [Contributor Covenant v2](https://www.contributor-covenant.org/) as our new code of conduct.  We think this is an important upgrade to make, especially as the project takes on more of a community-oriented approach to maintenance and governance.  Overall the sentiments are similar to hapi's existing code of conduct, but now we have:
  - Specific enforcement guidelines to follow.
  - A new channel for reporting complaints: send an email to **tsc@hapi.dev**.
  - A pledge to handle complaints promptly and to respect the privacy and security of the reporter.
  - Transparency regarding who is responsible to receive and act on any complaints: the listed members of the TSC.

Also important to note: security disclosures should be directed to **security@hapi.dev** going forward.  The rest of hapi's security policy is effectively unchanged: when in doubt, simply reach out to us directly over email rather than creating a public issue.

We hope these policies will keep the community secure in all senses of the word ☺️ 