### PR TITLE
doc: remove TSC member list and link to hapi README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -129,6 +129,6 @@ https://www.contributor-covenant.org/translations.
 ## Appendix A: The TSC Email Alias
 
 *Note*: At the current time, all email sent to the `tsc@hapi.dev` email
-alias is copied to all members of the [hapi Technical Steering Committee](https://github.com/hapijs/.github/blob/master/README.md#tsc-members).
+alias is copied to all members of the [hapi Technical Steering Committee](https://github.com/hapijs/hapi#technical-steering-committee-tsc-members).
 
 [homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -5,12 +5,7 @@ Organization policies
 The hapi community consists (non-exclusively) of participants in GitHub issues and PRs throughout the organization, users of the the hapi [Slack](https://join.slack.com/t/hapihour/shared_invite/zt-g5ortpsk-ErlnRA2rUcPIWES21oXBOg), project contributors, and the Technical Steering Committee (TSC).
 
 ### TSC Members
- - Devin Ivy ([@devinivy](https://github.com/devinivy))
- - Jonas Pauthier ([@nargonath](https://github.com/nargonath))
- - Lloyd Benson ([@lloydbenson](https://github.com/lloydbenson))
- - Nathan LaFreniere ([@nlf](https://github.com/nlf))
- - Wyatt Lyon Preul ([@geek](https://github.com/geek))
- - Colin Ihrig ([@cjihrig](https://github.com/cjihrig))
+> See [list of TSC members](https://github.com/hapijs/hapi#technical-steering-committee-tsc-members)
 
 ## Code of Conduct
 > See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This commit removes the TSC member list from this repository, and updates the links to now point to the TSC list on the hapi README.