### PR TITLE
Add staff sponsors section to sponsors.md, minor formatting/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,8 @@ The hapi community consists (non-exclusively) of participants in GitHub issues a
 ## Security and Disclosure
 > See [SECURITY.md](SECURITY.md)
 
+## Sponsors
+> See [SPONSORS.md](SPONSORS.md)
+
 ## Maintenance of Issues, PRs, and Releases
 > See [MAINTENANCE.md](MAINTENANCE.md)

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,22 +1,29 @@
 We'd like to thank our sponsors as well as the legacy sponsors who have supported hapi throughout the years. Thanks so much for your support!
+
+# Staff Sponsors
+- [Big Room Studios](https://www.bigroomstudios.com/)
+
 # Top Sponsors
-- Fabian Gündel / DataWrapper.de
+- Fabian Gündel / [DataWrapper.de](https://www.datawrapper.de/)
 - Devin Stewart
-- Raider.IO
+- [Raider.IO](https://raider.io/)
+
 # Backers
 - Steev Hise
 - Aori Nevo
 - Egor Ivkin
 - Paulo Vieira
 - Vlad Harb
+
 # Donations
-- BuySellAds
 - Zack McCartney
 - MW Felker
 - Benjamin Altpeter
 - Andrii
 - Kanika Sud
+
 ## Legacy Sponsors
+
 ### Top Sponsors
 - Alexander Alimovs
 - Alvin Lumowa
@@ -72,6 +79,7 @@ We'd like to thank our sponsors as well as the legacy sponsors who have supporte
 - Umut Şirin
 - Viswanadha Pratap Kondoju
 - Yehor Sergeenko
+
 ### Supporters
 - Adam Recvlohe
 - Adilson Schmitt Junior

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -2,6 +2,7 @@ We'd like to thank our sponsors as well as the legacy sponsors who have supporte
 
 # Staff Sponsors
 - [Big Room Studios](https://www.bigroomstudios.com/)
+- [Dixeed](https://dixeed.com/)
 
 # Top Sponsors
 - Fabian Gündel / [DataWrapper.de](https://www.datawrapper.de/)


### PR DESCRIPTION
We have decided to add a "staff sponsors" section to our sponsors list to account for contributions made by dedicating time in a recurring way.

I have also made some minor formatting changes for readability, added links to current sponsors' websites when listed, and added a link to the sponsors file from the readme.  Lastly, I ensured the current list is in sync with OpenCollective and removed BuySellAds as I believe their contributions to us are actually payments for ad placement on our website.

@Nargonath if I am not mistaken, your time is provided as a staff sponsorship.  If that is correct, we can also add Dixeed as part of this PR 👍 