### PR TITLE
Support min node version for workflows

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -2,6 +2,11 @@ name: ci
 
 on:
   workflow_call:
+    inputs:
+      min-node-version:
+        description: 'The minimum version of nodejs with which to run the workflow'
+        required: false
+        type: number
 
 jobs:
   test:
@@ -9,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ["*", "14", "12"]
+        node: ${{ inputs.min-node-version == 14 && fromJSON('["*", "16", "14"]') || fromJSON('["16", "14", "12"]') }}
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }}

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       min-node-version:
         description: 'The minimum version of nodejs with which to run the workflow'
-        required: false
         type: number
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -3,13 +3,19 @@ name: ci
 on:
   workflow_call:
 
+inputs:
+  min-node-version:
+    description: 'The minimum version of nodejs with which to run the workflow'
+    required: false
+    type: number
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ["*", "14", "12"]
+        node: ${{ inputs.min-node-version == 14 && fromJSON('["*", "16", "14"]') || fromJSON('["16", "14", "12"]') }}
         hapi: ["20", "19"]
 
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -2,12 +2,11 @@ name: ci
 
 on:
   workflow_call:
-
-inputs:
-  min-node-version:
-    description: 'The minimum version of nodejs with which to run the workflow'
-    required: false
-    type: number
+    inputs:
+      min-node-version:
+        description: 'The minimum version of nodejs with which to run the workflow'
+        type: number
+        required: false
 
 jobs:
   test:


### PR DESCRIPTION
As node v12 goes EOL and we begin dropping support on upcoming versions of our modules, we'll need a way to support two different sets of nodejs in CI.  I have added a `min-node-version` input to our workflows which will allow us to specify whether or not a given module should test node v12+ or v14+.  You can see an example of this working here: https://github.com/hapijs/podium/actions/runs/2049877975