### PR TITLE
Support minimum hapi version in workflows

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -7,6 +7,10 @@ on:
         description: 'The minimum version of nodejs with which to run the workflow'
         type: number
         required: false
+      min-hapi-version:
+        description: 'The minimum version of hapi with which to run the workflow'
+        type: number
+        required: false
 
 jobs:
   test:
@@ -15,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu, windows, macos]
         node: ${{ inputs.min-node-version == 14 && fromJSON('["*", "16", "14"]') || fromJSON('["16", "14", "12"]') }}
-        hapi: ["20", "19"]
+        hapi: ${{ inputs.min-hapi-version == 20 && fromJSON('["next", "20"]') || fromJSON('["20", "19"]') }}
 
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}


### PR DESCRIPTION
We need a way to support hapi v20+ on newly updated modules, rather than v19+ which is no longer supported commercially or otherwise.  To achieve this I've added a new workflow input `min-hapi-version` similar to the approach in #21.  While hapi v21 is in beta, we will use the `next` tag to target v21, and once v21 is published we will switch `next` to `v21`.

You can see an example of this working here: https://github.com/hapijs/inert/runs/7066284276