### PR TITLE
chore: bump github actions

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           check-latest: ${{ matrix.node == '*' }}

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           check-latest: ${{ matrix.node == '*' }}


### PR DESCRIPTION
Getting rid of those warnings, this is a safe bump as far as I can tell.

![image](https://user-images.githubusercontent.com/796194/197693803-649008f8-eeb3-4852-b866-ce02ddd1e249.png)
