### PR TITLE
chore: deprecate macos runners on legacy

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[ubuntu, latest], [windows, latest], [macos, 11]]
+        os: [[ubuntu, latest], [windows, latest]]
         node: ${{ inputs.min-node-version == 14 && fromJSON('["latest", "20", "18", "16", "14"]') || fromJSON('["16", "14", "12"]') }}
 
     runs-on: ${{ join(matrix.os, '-') }}

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[ubuntu, latest], [windows, latest], [macos, 11]]
+        os: [[ubuntu, latest], [windows, latest]]
         node: ${{ inputs.min-node-version == 14 && fromJSON('["latest", "20", "18", "16", "14"]') || fromJSON('["16", "14", "12"]') }}
         hapi: ${{ inputs.min-hapi-version == 20 && fromJSON('["next", "20"]') || fromJSON('["20", "19"]') }}
 


### PR DESCRIPTION
Current CIs are stuck because they require macos11 and runners are just gone. Since new runners don't really work, I think we have no other choice than removing them entirely.