### PR TITLE
chore: modernize shared CI workflows for node 22/24

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,22 +3,26 @@ name: ci
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
-        node: ['latest', '22', '24']
-
-    runs-on: ${{ matrix.os }}-latest
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: ['latest', 'lts/*', '22', '24']
+    runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} node@${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - name: install
-        run: npm install
-      - name: test
-        run: npm test
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -3,25 +3,28 @@ name: ci
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
-        node: ['latest', '22']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: ['latest', 'lts/*', '22', '24']
         hapi: ['next', '21']
-
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - name: install
-        run: npm install
-      - name: install hapi
-        run: npm install @hapi/hapi@${{ matrix.hapi }}
-      - name: test
-        run: npm test
+      - run: npm install
+      - run: npm install @hapi/hapi@${{ matrix.hapi }}
+      - run: npm test


### PR DESCRIPTION
## Summary

Lands 2026-best-practice hardening on top of the matrix modernization already in `min-node-22-hapi-21`.

Bumps `actions/checkout` and `actions/setup-node` to `@v6` (two majors ahead). Adds `permissions: contents: read` (least-privilege default), `concurrency:` (cancel superseded runs on push+amend cycles), and aligns the OS matrix style with GitHub Actions docs conventions (`os: [ubuntu-latest, ...]` + `runs-on: ${{ matrix.os }}`).

Adds `lts/*` to the node matrix alongside `latest` and the explicit `22`/`24` pins. `latest` catches upcoming-Current-line breakage early; `lts/*` tracks the newest active LTS so the matrix doesn't silently flip when a new major ships; `22` and `24` are the explicit support contract.

Aligns `ci-plugin.yml`'s node matrix with `ci-module.yml`'s (the base branch had `node 24` in module but not plugin).

## Breaking change for callers

Note that this branch already drops the `min-node-version` / `min-hapi-version` inputs (carried over from the base). Caller workflows passing them via `with:` will need those keys dropped before/when this branch merges to master — undeclared inputs to a reusable workflow are an error per GitHub Actions, not silently ignored.

Two ways to roll this out:

- Update all `hapijs/*` caller workflows in lockstep with the merge.
- Re-add the inputs as `required: false` no-ops here for a softer migration (one-line follow-up if anyone wants it).