### PR TITLE
ci: upgrade npm before install

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -24,5 +24,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+      # Node 22 ships npm 10, whose dependency resolver crashes on some
+      # optional-peer graphs with "Cannot read properties of null (reading
+      # edgesOut)". Upgrading first keeps the node@22 legs usable.
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm test

--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+      # Node 22 ships npm 10, whose dependency resolver crashes on some
+      # optional-peer graphs with "Cannot read properties of null (reading
+      # edgesOut)". Upgrading first keeps the node@22 legs usable.
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm install @hapi/hapi@${{ matrix.hapi }}
       - run: npm test


### PR DESCRIPTION
Node 22 ships npm 10, whose dependency resolver crashes on some optional-peer graphs:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

It fails during resolution, before any lifecycle script runs, so a consuming repo cannot work around it from `package.json`. The `node@22` legs of both shared workflows currently die on the first `npm install`, before a single test executes.

This is not hypothetical or specific to one repo. Any repo with `tsdown` in `devDependencies` reproduces it, which today means the TypeScript-converted packages. I confirmed `hoek`'s own `package.json` crashes npm 10 identically; its last green run predates the transitive publish that introduced the bug, so the failure is latent rather than absent.

What I ruled out as a per-repo fix, all verified against npm 10:

| Attempt | Result |
| --- | --- |
| `overrides` pinning `typescript`, `rolldown`, `rolldown-plugin-dts`, or the `@tsdown/*` optional peers | still crashes |
| Pinning the `typescript` devDependency to an exact version | still crashes |
| Committing a `package-lock.json` | works, but the ecosystem deliberately gitignores lockfiles |

Upgrading npm before install is the smallest change that keeps the `node@22` legs meaningful. It costs every other leg one fast step, and it becomes a no-op once Node 22 ships a fixed npm.

Both workflows are patched because both run a bare `npm install`: `ci-module.yml` for the libraries and `ci-plugin.yml` for the plugins.

One judgement worth a second opinion: this pins to `npm@latest` rather than a major. That keeps the workflow current without maintenance, at the cost of the runner picking up npm majors as they land. `npm@11` would be the conservative alternative if you would rather the version move deliberately.
